### PR TITLE
feat(ai): wire generateResponse into WhatsApp flow with guards and fa…

### DIFF
--- a/src/ai/aiEngine.ts
+++ b/src/ai/aiEngine.ts
@@ -1,7 +1,6 @@
 import OpenAI from "openai";
 import dotenv from "dotenv";
 
-// Carrega as variáveis de ambiente do arquivo .env
 dotenv.config();
 
 const client = new OpenAI({
@@ -9,13 +8,17 @@ const client = new OpenAI({
 });
 
 export async function generateResponse(context: string, userMsg: string) {
+
+  const ctx = context.slice(0, 600)
+  const msg = userMsg.slice(0, 800)
+
   const messages = [
     {
       role: "system",
       content:
         "You are a helpful personal stylist. Be concise, specific and friendly.",
     },
-    { role: "user", content: `Context: ${context}\nUser: ${userMsg}` },
+    { role: "user", content: `Context: ${ctx}\nUser: ${msg}` },
   ];
 
   const completion = await client.chat.completions.create({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,10 @@
 import { createSocket } from "./whatsappClient.js";
 import { startHealthCheck } from "./health.js";
+import "dotenv/config"
 
+if (!process.env.OPENAI_API_KEY) {
+  console.warn("[WARN] OPENAI_API_KEY not set – AI replies will be disabled.")
+}
 async function main() {
   await createSocket();
   startHealthCheck(30 * 60 * 1000);

--- a/src/whatsappClient.ts
+++ b/src/whatsappClient.ts
@@ -5,6 +5,7 @@ import {
 } from "@whiskeysockets/baileys";
 import qrcode from "qrcode-terminal";
 
+import { generateResponse } from "./ai/aiEngine.js"
 
 let _connectionStatus: 'connecting' | 'open' | 'close' | 'unknown' = 'unknown'
 
@@ -38,9 +39,49 @@ export async function createSocket() {
 
     if (!msg.message || msg.key.fromMe) return;
     
-    const text = msg.message.conversation ?? "";
+    const text = msg.message.conversation?.trim() ?? ""
+    const jid = msg.key.remoteJid!
+
     if (text.toLowerCase() === "ping") {
-      await sock.sendMessage(msg.key.remoteJid!, { text: "pong" });
+      await sock.sendMessage(jid, { text: "pong" })
+      return
+    }
+
+    if (text.length > 1500) {
+      await sock.sendMessage(jid, {
+        text:
+          "Mensagem muito longa para resposta automática. Pode resumir um pouco? 🙂",
+      })
+      return
+    }
+
+    const context = "User profile: TBD. Prefers concise, practical style tips."
+
+    if (!process.env.OPENAI_API_KEY) {
+      await sock.sendMessage(jid, {
+        text:
+          "No momento estou sem meu motor de IA. Tente novamente em alguns minutos!",
+      })
+      return
+    }
+
+    try {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), 25_000) // 25s
+      const reply = await generateResponse(context, text)
+      clearTimeout(timer)
+
+      const safeReply =
+        reply?.trim() ||
+        "Hmm… não tenho certeza. Pode me dar um pouco mais de contexto?"
+
+      await sock.sendMessage(jid, { text: safeReply })
+    } catch (err: any) {
+      console.error("[AI ERROR]", err?.message || err)
+      await sock.sendMessage(jid, {
+        text:
+          "Tive um probleminha para pensar na resposta agora 😅. Tenta de novo já já.",
+      })
     }
   });
 }


### PR DESCRIPTION
* call generateResponse() for non-ping messages
* basic guards (length, timeout) and error fallback
* context stub to be replaced by Onboarding/Profile
